### PR TITLE
- Switched identifier property from String to UUID, improved unit tests

### DIFF
--- a/SparkChamber/SparkChamber/SparkDetector+UIKit.swift
+++ b/SparkChamber/SparkChamber/SparkDetector+UIKit.swift
@@ -194,7 +194,7 @@ private extension UIView {
 			return nil
 		}
 		
-		guard let result = events() , !result.isEmpty else {
+		guard let result = events(), !result.isEmpty else {
 			return nil
 		}
 		

--- a/SparkChamber/SparkChamber/SparkEvent.swift
+++ b/SparkChamber/SparkChamber/SparkEvent.swift
@@ -26,12 +26,14 @@ import Foundation
 /**
 An event's trigger type.
 
-- None: The event has no trigger
-- DidAppear: The event's action will trigger if attached to a view that has appeared
-- DidDisappear: The event's action will trigger if attached to a view that has disappeared
-- DidEndTouch: The event's action will trigger if attached to a responder that has received a touch event with phase 'Ended'
-- DidBeginScroll: The event's action will trigger if attached to a scroll view after scrolling has begun
-- TargetAction: The event's action will trigger if attached to a responder that has an event action tied to the Detector
+- none: The event has no trigger
+- didAppear: The event's action will trigger if attached to a view that has appeared
+- didDisappear: The event's action will trigger if attached to a view that has disappeared
+- didEndTouch: The event's action will trigger if attached to a responder that has received a touch event with phase 'Ended'
+- targetAction: The event's action will trigger if attached to a responder that has an event action tied to the Detector
+- didBeginScroll: The event's action will trigger if attached to a scroll view after scrolling has begun
+- didSelect: The event's action will trigger if attached to a UIControl after it has been selected
+- didDeselect: The event's action will trigger if attached to a UIControl after it has been deselected
 
 */
 @objc public enum SparkTriggerType: Int {
@@ -93,7 +95,7 @@ A Spark Event model object, composed of a trigger (enum), action (closure), trac
 	The event's identifier, assignable for identification purposes. 
 	Returns a unique identifier string if none has been assigned.
 	*/
-	final public var identifier: String? = UUID().uuidString
+	final public var identifier: UUID? = UUID()
 	
 	// Designated initializer
 	
@@ -102,15 +104,13 @@ A Spark Event model object, composed of a trigger (enum), action (closure), trac
 	
 	- parameter trigger: The event's trigger, supplied as a SparkTriggerType
 	- parameter trace: An optional String that will print to the console after the event's action has executed
-	- parameter identifier: An optional String that may be assigned to allow the event to be uniquely identified
 	- parameter action: An optional completion closure/block that will execute when the event's trigger conditions have been met
 	
 	- returns: An initialized object, or nil if an object could not be created
 	*/
-	public init(trigger: SparkTriggerType, trace: String?, identifier: String?, action: SparkEventActionBlock?) {
+	public init(trigger: SparkTriggerType, trace: String?, action: SparkEventActionBlock?) {
 		self.trigger = trigger
 		self.trace = trace
-		self.identifier = identifier
 		self.action = action
 		
 		super.init()
@@ -121,12 +121,15 @@ A Spark Event model object, composed of a trigger (enum), action (closure), trac
 	
 	- parameter trigger: The event's trigger, supplied as a SparkTriggerType
 	- parameter trace: An optional String that will print to the console after the event's action has executed
+	- parameter identifier: An optional UUID that may be assigned to allow the event to be uniquely identified
 	- parameter action: An optional completion closure/block that will execute when the event's trigger conditions have been met
 	
 	- returns: An initialized object, or nil if an object could not be created
 	*/
-	public convenience init(trigger: SparkTriggerType, trace: String?, action: SparkEventActionBlock?) {
-		self.init(trigger: trigger, trace: trace, identifier: nil, action: action)
+	public convenience init(trigger: SparkTriggerType, trace: String?, identifier: UUID?, action: SparkEventActionBlock?) {
+		self.init(trigger: trigger, trace: trace, action: action)
+		
+		self.identifier = identifier;
 	}
 	
 	/**
@@ -138,13 +141,13 @@ A Spark Event model object, composed of a trigger (enum), action (closure), trac
 	- returns: An initialized object, or nil if an object could not be created
 	*/
 	public convenience init(trigger: SparkTriggerType, action: SparkEventActionBlock?) {
-		self.init(trigger: trigger, trace: nil, identifier: nil, action: action)
+		self.init(trigger: trigger, trace: nil, action: action)
 	}
 	
 	// CustomStringConvertible protocol
 	
 	override open var description: String {
-		return("\(super.description)\n   trigger = \(trigger.description)\n   trace = \(trace ?? "nil")\n   identifier = \(identifier ?? "nil")\n   action = \(String(describing: action))")
+		return("\(super.description)\n   trigger = \(trigger.description)\n   trace = \(trace ?? "nil")\n   identifier = \(identifier?.uuidString ?? "nil")\n   action = \(String(describing: action))")
 	}
 	
 	// NSCopying protocol
@@ -163,11 +166,11 @@ A Spark Event model object, composed of a trigger (enum), action (closure), trac
 				return false
 			}
 			
-			guard trace == rhs.trace else {
+			guard identifier == rhs.identifier else {
 				return false
 			}
 			
-			guard identifier == rhs.identifier else {
+			guard trace == rhs.trace else {
 				return false
 			}
 			

--- a/SparkChamber/SparkChamberTests/SparkDetector+UIKitTests.swift
+++ b/SparkChamber/SparkChamberTests/SparkDetector+UIKitTests.swift
@@ -87,7 +87,7 @@ class SparkDetectorUIKitTests: XCTestCase {
 	func testSparkDetectorUIControlOutOfBoundTouchesReceived() {
 		let button = UIButton()
 		
-		let sparkEvent = SparkEvent(trigger: SparkTriggerType.didEndTouch, trace: "foo") {
+		let sparkEvent = SparkEvent(trigger: SparkTriggerType.didEndTouch) {
 			_ in
 			XCTFail("A Spark Event's action block was triggered when it shouldn't have been.")
 		}
@@ -104,7 +104,7 @@ class SparkDetectorUIKitTests: XCTestCase {
 	func testSparkDetectorUIControlTouchesReceived() {
 		let button = TouchInsideButtonMock()
 		
-		let sparkEvent = SparkEvent(trigger: SparkTriggerType.didEndTouch, trace: "foo", action: nil)
+		let sparkEvent = SparkEvent(trigger: SparkTriggerType.didEndTouch, action: nil)
 		button.sparkEvents = [sparkEvent]
 		
 		let touch = UITouchMock()
@@ -120,7 +120,7 @@ class SparkDetectorUIKitTests: XCTestCase {
 		let cell = UITableViewCell()
 		tableView.addSubview(cell)
 		
-		let sparkEvent = SparkEvent(trigger: SparkTriggerType.didEndTouch, trace: "foo", action: nil)
+		let sparkEvent = SparkEvent(trigger: SparkTriggerType.didEndTouch, action: nil)
 		cell.sparkEvents = [sparkEvent]
 		
 		let touch = UITouchMock()
@@ -138,7 +138,7 @@ class SparkDetectorUIKitTests: XCTestCase {
 		touch.view = PointInsideViewMock()
 		touch.view.isUserInteractionEnabled = true
 		
-		let sparkEvent = SparkEvent(trigger: SparkTriggerType.didEndTouch, trace: "foo", action: nil)
+		let sparkEvent = SparkEvent(trigger: SparkTriggerType.didEndTouch, action: nil)
 		touch.view.sparkEvents = [sparkEvent]
 		
 		let result = SparkDetector.trackEnded(withTouches: fakeTouches)
@@ -152,7 +152,7 @@ class SparkDetectorUIKitTests: XCTestCase {
 		touch.view.isUserInteractionEnabled = true
 		touch.view.bounds = CGRect.zero
 		
-		let sparkEvent = SparkEvent(trigger: SparkTriggerType.didEndTouch, trace: "foo") {
+		let sparkEvent = SparkEvent(trigger: SparkTriggerType.didEndTouch) {
 			_ in
 			XCTFail("A Spark Event's action block was triggered when it shouldn't have been.")
 		}
@@ -181,7 +181,7 @@ class SparkDetectorUIKitTests: XCTestCase {
 		touch.view = PointInsideViewMock()
 		touch.view.isUserInteractionEnabled = false
 		
-		let sparkEvent = SparkEvent(trigger: SparkTriggerType.didEndTouch, trace: "foo") {
+		let sparkEvent = SparkEvent(trigger: SparkTriggerType.didEndTouch) {
 			_ in
 			XCTFail("A Spark Event's action block was triggered when it shouldn't have been.")
 		}
@@ -199,7 +199,7 @@ class SparkDetectorUIKitTests: XCTestCase {
 		touch.view.isUserInteractionEnabled = true
 		touch.phase = UITouchPhase.began
 		
-		let sparkEvent = SparkEvent(trigger: SparkTriggerType.didEndTouch, trace: "foo") {
+		let sparkEvent = SparkEvent(trigger: SparkTriggerType.didEndTouch) {
 			_ in
 			XCTFail("A Spark Event's action block was triggered when it shouldn't have been.")
 		}
@@ -223,7 +223,7 @@ class SparkDetectorUIKitTests: XCTestCase {
 	func testSparkDetectorUIKitTrackTargetActionForView() {
 		let view = UIView()
 		
-		let sparkEvent = SparkEvent(trigger: SparkTriggerType.targetAction, trace: "foo", action: nil)
+		let sparkEvent = SparkEvent(trigger: SparkTriggerType.targetAction, action: nil)
 		view.sparkEvents = [sparkEvent]
 		
 		let result = SparkDetector.trackTargetAction(forView: view)
@@ -254,7 +254,7 @@ class SparkDetectorUIKitTests: XCTestCase {
 	func testSparkDetectorUIKitTrackDisplayForViews() {
 		let view = UIView()
 		
-		let sparkEvent = SparkEvent(trigger: SparkTriggerType.didAppear, trace: "foo", action: nil)
+		let sparkEvent = SparkEvent(trigger: SparkTriggerType.didAppear, action: nil)
 		view.sparkEvents = [sparkEvent]
 		
 		let result = SparkDetector.trackDisplay(forViews: [view])
@@ -278,7 +278,7 @@ class SparkDetectorUIKitTests: XCTestCase {
 	
 	func testSparkDetectorUIKitTrackDisplayForView() {
 		let view = UIView()
-		let sparkEvent = SparkEvent(trigger: SparkTriggerType.didAppear, trace: "foo", action: nil)
+		let sparkEvent = SparkEvent(trigger: SparkTriggerType.didAppear, action: nil)
 		view.sparkEvents = [sparkEvent]
 		
 		let result = SparkDetector.trackDisplay(forViews: [view])
@@ -303,7 +303,7 @@ class SparkDetectorUIKitTests: XCTestCase {
 	
 	func testSparkDetectorUIKitTrackDisplayForViewIgnored() {
 		let view = UIView()
-		let sparkEvent = SparkEvent(trigger: SparkTriggerType.didEndTouch, trace: "foo") {
+		let sparkEvent = SparkEvent(trigger: SparkTriggerType.didEndTouch) {
 			_ in
 			XCTFail("A Spark Event's action block was triggered when it shouldn't have been.")
 		}
@@ -315,7 +315,7 @@ class SparkDetectorUIKitTests: XCTestCase {
 	
 	func testSparkDetectorUIKitTrackEndDisplayingViews() {
 		let view = UIView()
-		let sparkEvent = SparkEvent(trigger: SparkTriggerType.didDisappear, trace: "foo", action: nil)
+		let sparkEvent = SparkEvent(trigger: SparkTriggerType.didDisappear, action: nil)
 		view.sparkEvents = [sparkEvent]
 		
 		let result = SparkDetector.trackEndDisplaying(forViews: [view])
@@ -339,7 +339,7 @@ class SparkDetectorUIKitTests: XCTestCase {
 	
 	func testSparkDetectorUIKitTrackEndDisplayingView() {
 		let view = UIView()
-		let sparkEvent = SparkEvent(trigger: SparkTriggerType.didDisappear, trace: "foo", action: nil)
+		let sparkEvent = SparkEvent(trigger: SparkTriggerType.didDisappear, action: nil)
 		view.sparkEvents = [sparkEvent]
 		
 		let result = SparkDetector.trackEndDisplaying(forViews: [view])
@@ -356,7 +356,7 @@ class SparkDetectorUIKitTests: XCTestCase {
 	
 	func testSparkDetectorUIKitTrackEndDisplayingViewIgnored() {
 		let view = UIView()
-		let sparkEvent = SparkEvent(trigger: SparkTriggerType.didEndTouch, trace: "foo") {
+		let sparkEvent = SparkEvent(trigger: SparkTriggerType.didEndTouch) {
 			_ in
 			XCTFail("A Spark Event's action block was triggered when it shouldn't have been.")
 		}
@@ -369,7 +369,7 @@ class SparkDetectorUIKitTests: XCTestCase {
 	func testSparkDetectorUIKitTrackBeganScrollingView() {
 		let view = UIScrollViewTrackingMock()
 		
-		let sparkEvent = SparkEvent(trigger: SparkTriggerType.didBeginScroll, trace: "foo", action: nil)
+		let sparkEvent = SparkEvent(trigger: SparkTriggerType.didBeginScroll, action: nil)
 		view.sparkEvents = [sparkEvent]
 		
 		let result = SparkDetector.trackBeganScrolling(forScrollView: view)
@@ -399,7 +399,7 @@ class SparkDetectorUIKitTests: XCTestCase {
 	
 	func testSparkDetectorUIKitTrackBeganScrollingViewIgnored() {
 		let view = UIScrollView()
-		let sparkEvent = SparkEvent(trigger: SparkTriggerType.didBeginScroll, trace: "foo") {
+		let sparkEvent = SparkEvent(trigger: SparkTriggerType.didBeginScroll) {
 			_ in
 			XCTFail("A Spark Event's action block was triggered when it shouldn't have been.")
 		}
@@ -412,7 +412,7 @@ class SparkDetectorUIKitTests: XCTestCase {
 	func testSparkDetectorUIKitTrackDidSelectControl() {
 		let control = UIControl()
 		
-		let sparkEvent = SparkEvent(trigger: SparkTriggerType.didSelect, trace: "foo", action: nil)
+		let sparkEvent = SparkEvent(trigger: SparkTriggerType.didSelect, action: nil)
 		control.sparkEvents = [sparkEvent]
 		
 		let result = SparkDetector.trackDidSelect(forControl: control)
@@ -443,7 +443,7 @@ class SparkDetectorUIKitTests: XCTestCase {
 	func testSparkDetectorUIKitTrackDidDeselectControl() {
 		let control = UIControl()
 		
-		let sparkEvent = SparkEvent(trigger: SparkTriggerType.didDeselect, trace: "foo", action: nil)
+		let sparkEvent = SparkEvent(trigger: SparkTriggerType.didDeselect, action: nil)
 		control.sparkEvents = [sparkEvent]
 		
 		let result = SparkDetector.trackDidDeselect(forControl: control)

--- a/SparkChamber/SparkChamberTests/SparkDetectorTests.swift
+++ b/SparkChamber/SparkChamberTests/SparkDetectorTests.swift
@@ -37,7 +37,7 @@ class SparkDetectorTests: XCTestCase {
 	}
 	
 	func testSparkDetectorSendEvents() {
-		let event: SparkEvent = SparkEvent(trigger: SparkTriggerType.didAppear, trace: "foo", action: nil)
+		let event: SparkEvent = SparkEvent(trigger: SparkTriggerType.didAppear, action: nil)
 		
 		let result = SparkDetector.send([event])
 		XCTAssertTrue(result, "A Spark Event failed to be tracked.")

--- a/SparkChamber/SparkChamberTests/SparkEventTests.swift
+++ b/SparkChamber/SparkChamberTests/SparkEventTests.swift
@@ -33,41 +33,95 @@ class SparkEventTests: XCTestCase {
 		super.tearDown()
 	}
 	
-	func testSparkEventConvenienceInitWithTriggerAndAction() {
-		let sparkEvent = SparkEvent(trigger: SparkTriggerType.none, action: nil)
-		
-		XCTAssertNotNil(sparkEvent, "A Spark Event wasn't returned when using the convenience initializer.")
-	}
-	
-	func testSparkEventConvenienceInitWithTriggerActionAndTrace() {
-		let sparkEvent = SparkEvent(trigger: SparkTriggerType.none, trace: nil, action: nil)
-		
-		XCTAssertNotNil(sparkEvent, "A Spark Event wasn't returned when using the convenience initializer.")
-	}
-	
-	func testSparkEventInitWithoutTrace() {
-		let sparkEvent = SparkEvent(trigger: SparkTriggerType.none, trace: nil, identifier: nil, action: nil)
-		
-		XCTAssertNotNil(sparkEvent, "A Spark Event wasn't returned after having been set without a trace.")
-	}
-	
-	func testSparkEventInitWithoutClosure() {
-		let sparkEvent = SparkEvent(trigger: SparkTriggerType.none, trace: "foo", identifier: nil, action: nil)
-		
-		XCTAssertNotNil(sparkEvent, "A Spark Event wasn't returned after having been set without a closure.")
-	}
-	
-	func testSparkEventInitWithParams() {
-		let sparkEvent = SparkEvent(trigger: SparkTriggerType.none, trace: "foo", identifier: "bar") {
+	func testSparkEventDefaultInit() {
+		let sparkEvent = SparkEvent(trigger: SparkTriggerType.none, trace: "foo") {
 			_ in
 			print("success") // This is only here to make sure a non-empty action closure is present for the event.
 		}
 		
-		XCTAssertNotNil(sparkEvent, "A Spark Event wasn't returned after having been set with parameters.")
+		XCTAssertNotNil(sparkEvent, "A Spark Event wasn't returned after having been set using the default initializer.")
+		XCTAssertNotNil(sparkEvent.trigger, "A Spark Event's trigger wasn't returned after having been set using the default initializer.")
+		XCTAssert(sparkEvent.trigger == SparkTriggerType.none, "A Spark Event's trigger didn't match what was set using the default initializer.")
+		XCTAssertNotNil(sparkEvent.trace, "A Spark Event's trace wasn't returned after having been set using the default initializer.")
+		XCTAssert(sparkEvent.trace == "foo", "A Spark Event's trace didn't match what was set using the default initializer.")
+		XCTAssertNotNil(sparkEvent.identifier, "A Spark Event's default identifier value wasn't returned after having been set using the default initializer.")
+		XCTAssertNotNil(sparkEvent.action, "A Spark Event's action wasn't returned after having been set using the default initializer.")
+	}
+	
+	func testSparkEventConvenienceInitWithTriggerTraceIdentifierAndAction() {
+		let identifier = UUID()
+		let sparkEvent = SparkEvent(trigger: SparkTriggerType.none, trace: "foo", identifier: identifier) {
+			_ in
+			print("success") // This is only here to make sure a non-empty action closure is present for the event.
+		}
+		
+		XCTAssertNotNil(sparkEvent, "A Spark Event wasn't returned when using a convenience initializer.")
+		XCTAssertNotNil(sparkEvent.trigger, "A Spark Event's trigger wasn't returned after having been set using a convenience initializer.")
+		XCTAssert(sparkEvent.trigger == SparkTriggerType.none, "A Spark Event's trigger didn't match what was set using a convenience initializer.")
+		XCTAssertNotNil(sparkEvent.trace, "A Spark Event's trace wasn't returned after having been set using a convenience initializer.")
+		XCTAssert(sparkEvent.trace == "foo", "A Spark Event's trace didn't match what was set using a convenience initializer.")
+		XCTAssertNotNil(sparkEvent.identifier, "A Spark Event's identifier wasn't returned after having been set using a convenience initializer.")
+		XCTAssert(sparkEvent.identifier == identifier, "A Spark Event's identifier didn't match what was set using a convenience initializer.")
+		XCTAssertNotNil(sparkEvent.action, "A Spark Event's action wasn't returned after having been set using a convenience initializer.")
+	}
+	
+	func testSparkEventConvenienceInitWithTriggerAndAction() {
+		let sparkEvent = SparkEvent(trigger: SparkTriggerType.none) {
+			_ in
+			print("success") // This is only here to make sure a non-empty action closure is present for the event.
+		}
+
+		XCTAssertNotNil(sparkEvent, "A Spark Event wasn't returned when using the convenience initializer.")
+		XCTAssertNotNil(sparkEvent.trigger, "A Spark Event's trigger wasn't returned after having been set using a convenience initializer.")
+		XCTAssert(sparkEvent.trigger == SparkTriggerType.none, "A Spark Event's trigger didn't match what was set using a convenience initializer.")
+		XCTAssertNil(sparkEvent.trace, "A Spark Event's trace didn't return nil after having been set using a convenience initializer.")
+		XCTAssertNotNil(sparkEvent.identifier, "A Spark Event's default identifier value wasn't returned after having been set using  a convenience initializer.")
+		XCTAssertNotNil(sparkEvent.action, "A Spark Event's action wasn't returned after having been set using a convenience initializer.")
+	}
+	
+	func testSparkEventInitWithNilTrace() {
+		let sparkEvent = SparkEvent(trigger: SparkTriggerType.none, trace: nil) {
+			_ in
+			print("success") // This is only here to make sure a non-empty action closure is present for the event.
+		}
+		
+		XCTAssertNotNil(sparkEvent, "A Spark Event wasn't returned after having been set without a trace.")
+		XCTAssertNotNil(sparkEvent.trigger, "A Spark Event's trigger wasn't returned after having been set using a convenience initializer.")
+		XCTAssert(sparkEvent.trigger == SparkTriggerType.none, "A Spark Event's trigger didn't match what was set using a convenience initializer.")
+		XCTAssertNil(sparkEvent.trace, "A Spark Event's trace didn't return nil after having been set using a convenience initializer.")
+		XCTAssertNotNil(sparkEvent.identifier, "A Spark Event's default identifier value wasn't returned after having been set using  a convenience initializer.")
+		XCTAssertNotNil(sparkEvent.action, "A Spark Event's action wasn't returned after having been set using a convenience initializer.")
+	}
+	
+	func testSparkEventInitWithNilIdentifier() {
+		let sparkEvent = SparkEvent(trigger: SparkTriggerType.none, trace: "foo", identifier: nil) {
+			_ in
+			print("success") // This is only here to make sure a non-empty action closure is present for the event.
+		}
+		
+		XCTAssertNotNil(sparkEvent, "A Spark Event wasn't returned after having been set without a trace.")
+		XCTAssertNotNil(sparkEvent.trigger, "A Spark Event's trigger wasn't returned after having been set using a convenience initializer.")
+		XCTAssert(sparkEvent.trigger == SparkTriggerType.none, "A Spark Event's trigger didn't match what was set using a convenience initializer.")
+		XCTAssertNotNil(sparkEvent.trace, "A Spark Event's trace wasn't returned after having been set using a convenience initializer.")
+		XCTAssert(sparkEvent.trace == "foo", "A Spark Event's trace didn't match what was set using a convenience initializer.")
+		XCTAssertNil(sparkEvent.identifier, "A Spark Event's identifier didn't return nil after having been set using a convenience initializer.")
+		XCTAssertNotNil(sparkEvent.action, "A Spark Event's action wasn't returned after having been set using a convenience initializer.")
+	}
+	
+	func testSparkEventInitWithNilAction() {
+		let sparkEvent = SparkEvent(trigger: SparkTriggerType.none, trace: "foo", action: nil)
+		
+		XCTAssertNotNil(sparkEvent, "A Spark Event wasn't returned after having been set without a closure.")
+		XCTAssertNotNil(sparkEvent.trigger, "A Spark Event's trigger wasn't returned after having been set using a convenience initializer.")
+		XCTAssert(sparkEvent.trigger == SparkTriggerType.none, "A Spark Event's trigger didn't match what was set using a convenience initializer.")
+		XCTAssertNotNil(sparkEvent.trace, "A Spark Event's trace wasn't returned after having been set using a convenience initializer.")
+		XCTAssert(sparkEvent.trace == "foo", "A Spark Event's trace didn't match what was set using a convenience initializer.")
+		XCTAssertNotNil(sparkEvent.identifier, "A Spark Event's default identifier value wasn't returned after having been set using  a convenience initializer.")
+		XCTAssertNil(sparkEvent.action, "A Spark Event's action didn't return nil after having been set using a convenience initializer.")
 	}
 	
 	func testSparkEventCopyWithZone() {
-		let sparkEvent = SparkEvent(trigger: SparkTriggerType.none, trace: "foo", identifier: "bar") {
+		let sparkEvent = SparkEvent(trigger: SparkTriggerType.none, trace: "foo") {
 			_ in
 			print("success") // This is only here to make sure a non-empty action closure is present for the event.
 		}
@@ -82,27 +136,30 @@ class SparkEventTests: XCTestCase {
 			print("success") // This is only here to make sure a non-empty action closure is present for the event.
 		}
 
-		let sparkEventOne = SparkEvent(trigger: SparkTriggerType.none, trace: "foo", identifier: "bar", action: sparkAction)
-		let sparkEventTwo = SparkEvent(trigger: SparkTriggerType.none, trace: "foo", identifier: "bar", action: sparkAction)
+		let identifier = UUID()
+		let sparkEventOne = SparkEvent(trigger: SparkTriggerType.none, trace: "foo", identifier: identifier, action: sparkAction)
+		let sparkEventTwo = SparkEvent(trigger: SparkTriggerType.none, trace: "foo", identifier: identifier, action: sparkAction)
 		
 		XCTAssert(sparkEventOne == sparkEventTwo, "Two Spark Events with the same data didn't prove equivalent using ==, and should have.")
 		XCTAssert(sparkEventOne.isEqual(sparkEventTwo), "Two Spark Events with the same data didn't prove equivalent using isEqual(), and should have.")
 	}
 	
 	func testSparkEventTriggerIsNotEqual() {
-		let sparkEventOne = SparkEvent(trigger: SparkTriggerType.didAppear, trace: "foo", identifier: "bar", action: nil)
-		let sparkEventTwo = SparkEvent(trigger: SparkTriggerType.none, trace: "foo", identifier: "bar", action: nil)
+		let identifier = UUID()
+		let sparkEventOne = SparkEvent(trigger: SparkTriggerType.didAppear, trace: "foo", identifier: identifier, action: nil)
+		let sparkEventTwo = SparkEvent(trigger: SparkTriggerType.none,  trace: "foo", identifier: identifier, action: nil)
 		
 		XCTAssertFalse(sparkEventOne == sparkEventTwo, "Two Spark Events with dissimilar data didn't fail equivalence using ==, and should have.")
 		XCTAssertFalse(sparkEventOne.isEqual(sparkEventTwo), "Two Spark Events with dissimilar data didn't fail equivalence using isEqual(), and should have.")
 	}
 	
 	func testSparkEventRightActionIsNil() {
-		let sparkEventOne = SparkEvent(trigger: SparkTriggerType.none, trace: "foo", identifier: "bar")  {
+		let identifier = UUID()
+		let sparkEventOne = SparkEvent(trigger: SparkTriggerType.none, trace: nil, identifier: identifier) {
 			_ in
 			print("success") // This is only here to make sure a non-empty action closure is present for the event.
 		}
-		let sparkEventTwo = SparkEvent(trigger: SparkTriggerType.none, trace: "foo", identifier: "bar", action: nil)
+		let sparkEventTwo = SparkEvent(trigger: SparkTriggerType.none, trace: nil, identifier: identifier, action: nil)
 
 		
 		XCTAssertFalse(sparkEventOne == sparkEventTwo, "Two Spark Events with dissimilar data didn't fail equivalence using ==, and should have.")
@@ -110,8 +167,9 @@ class SparkEventTests: XCTestCase {
 	}
 	
 	func testSparkEventLeftActionIsNil() {
-		let sparkEventOne = SparkEvent(trigger: SparkTriggerType.none, trace: "foo", identifier: "bar", action: nil)
-		let sparkEventTwo = SparkEvent(trigger: SparkTriggerType.none, trace: "foo", identifier: "bar") {
+		let identifier = UUID()
+		let sparkEventOne = SparkEvent(trigger: SparkTriggerType.none, trace: nil, identifier: identifier, action: nil)
+		let sparkEventTwo = SparkEvent(trigger: SparkTriggerType.none, trace: nil, identifier: identifier) {
 			_ in
 			print("success") // This is only here to make sure a non-empty action closure is present for the event.
 		}
@@ -121,31 +179,42 @@ class SparkEventTests: XCTestCase {
 	}
 	
 	func testSparkEventBothActionsAreNil() {
-		let sparkEventOne = SparkEvent(trigger: SparkTriggerType.none, trace: "foo", identifier: "bar", action: nil)
-		let sparkEventTwo = SparkEvent(trigger: SparkTriggerType.none, trace: "foo", identifier: "bar", action: nil)
+		let identifier = UUID()
+		let sparkEventOne = SparkEvent(trigger: SparkTriggerType.none, trace: nil, identifier: identifier, action: nil)
+		let sparkEventTwo = SparkEvent(trigger: SparkTriggerType.none, trace: nil, identifier: identifier, action: nil)
 		
 		XCTAssert(sparkEventOne == sparkEventTwo, "Two Spark Events with the same data didn't prove equivalent using ==, and should have.")
 		XCTAssert(sparkEventOne.isEqual(sparkEventTwo), "Two Spark Events with the same data didn't prove equivalent using isEqual(), and should have.")
 	}
 	
 	func testSparkEventTraceIsNotEqual() {
-		let sparkEventOne = SparkEvent(trigger: SparkTriggerType.none, trace: "foo", identifier: "bar", action: nil)
-		let sparkEventTwo = SparkEvent(trigger: SparkTriggerType.none, trace: "oof", identifier: "bar", action: nil)
+		let identifier = UUID()
+		let sparkEventOne = SparkEvent(trigger: SparkTriggerType.none, trace: "foo", identifier: identifier, action: nil)
+		let sparkEventTwo = SparkEvent(trigger: SparkTriggerType.none, trace: "oof", identifier: identifier, action: nil)
 		
 		XCTAssertFalse(sparkEventOne == sparkEventTwo, "Two Spark Events with dissimilar data didn't fail equivalence using ==, and should have.")
 		XCTAssertFalse(sparkEventOne.isEqual(sparkEventTwo), "Two Spark Events with dissimilar data didn't fail equivalence using isEqual(), and should have.")
 	}
 	
+	func testSparkEventIdentifierIsEqual() {
+		let identifier = UUID()
+		let sparkEventOne = SparkEvent(trigger: SparkTriggerType.none, trace: nil, identifier: identifier, action: nil)
+		let sparkEventTwo = SparkEvent(trigger: SparkTriggerType.none, trace: nil, identifier: identifier, action: nil)
+		
+		XCTAssert(sparkEventOne == sparkEventTwo, "Two Spark Events with the same data didn't prove equivalent using ==, and should have.")
+		XCTAssert(sparkEventOne.isEqual(sparkEventTwo), "Two Spark Events with the same data didn't prove equivalent using isEqual(), and should have.")
+	}
+	
 	func testSparkEventIdentifierIsNotEqual() {
-		let sparkEventOne = SparkEvent(trigger: SparkTriggerType.none, trace: "foo", identifier: "rab", action: nil)
-		let sparkEventTwo = SparkEvent(trigger: SparkTriggerType.none, trace: "foo", identifier: "bar", action: nil)
+		let sparkEventOne = SparkEvent(trigger: SparkTriggerType.none, action: nil)
+		let sparkEventTwo = SparkEvent(trigger: SparkTriggerType.none, action: nil)
 		
 		XCTAssertFalse(sparkEventOne == sparkEventTwo, "Two Spark Events with dissimilar data didn't fail equivalence using ==, and should have.")
 		XCTAssertFalse(sparkEventOne.isEqual(sparkEventTwo), "Two Spark Events with dissimilar data didn't fail equivalence using isEqual(), and should have.")
 	}
 	
 	func testSparkEventIsNotEqualToObject() {
-		let sparkEvent = SparkEvent(trigger: SparkTriggerType.none, trace: "foo", identifier: "bar") {
+		let sparkEvent = SparkEvent(trigger: SparkTriggerType.none, trace: "foo") {
 			_ in
 			print("success") // This is only here to make sure a non-empty action closure is present for the event.
 		}
@@ -157,13 +226,13 @@ class SparkEventTests: XCTestCase {
 	}
 	
 	func testSparkEventDescription() {
-		let sparkEvent = SparkEvent(trigger: SparkTriggerType.none, trace: "foo", identifier: "bar") {
+		let sparkEvent = SparkEvent(trigger: SparkTriggerType.none, trace: "foo") {
 			_ in
 			print("success") // This is only here to make sure a non-empty action closure is present for the event.
 		}
 		
 		let description = sparkEvent.description
-		let expectedDescription = "trigger = \(sparkEvent.trigger.description)\n   trace = \(sparkEvent.trace ?? "nil")\n   identifier = \(sparkEvent.identifier ?? "nil")\n   action = \(String(describing: sparkEvent.action))"
+		let expectedDescription = "trigger = \(sparkEvent.trigger.description)\n   trace = \(sparkEvent.trace ?? "nil")\n   identifier = \(sparkEvent.identifier?.uuidString ?? "nil")\n   action = \(String(describing: sparkEvent.action))"
 		
 		XCTAssert(description.contains(expectedDescription), "A Spark Event didn't return its description correctly.")
 	}
@@ -175,7 +244,7 @@ class SparkEventTests: XCTestCase {
 		}
 
 		let description = sparkEvent.description
-		let expectedDescription = "trigger = \(sparkEvent.trigger.description)\n   trace = \(sparkEvent.trace ?? "nil")\n   identifier = \(sparkEvent.identifier ?? "nil")\n   action = \(String(describing: sparkEvent.action))"
+		let expectedDescription = "trigger = \(sparkEvent.trigger.description)\n   trace = \(sparkEvent.trace ?? "nil")\n   identifier = \(sparkEvent.identifier?.uuidString ?? "nil")\n   action = \(String(describing: sparkEvent.action))"
 		
 		XCTAssert(description.contains(expectedDescription), "A Spark Event didn't return its description correctly.")
 	}


### PR DESCRIPTION
- Switched the Spark Event `identifier` property to use UUID for performance benefit
- Updated, improved unit tests
- Code, comment clean-up